### PR TITLE
CU-86etmw3vv - Grana-Me domain issue

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,7 +25,7 @@
 // export default nextConfig;
 /**
  * 
-// /** @type {import('next').NextConfig} */
+/** @type {import('next').NextConfig} 
 // const nextConfig = {
 //   images: {
 //     domains: [
@@ -67,6 +67,86 @@
 
 // export default nextConfig;
 
+// /** @type {import('next').NextConfig} 
+// const nextConfig = {
+//   images: {
+//     domains: [
+//       "bubblev2.s3.us-east-1.amazonaws.com",
+//       "talktango.estamart.com",
+//       "picsum.photos",
+//     ],
+//   },
+//   async redirects() {
+//     return [
+//       {
+//         source: "/:path*",
+//         has: [{ type: "host", value: "www.granameapp.com" }],
+//         destination: "https://granameapp.com/:path*",
+//         permanent: true,
+//       },
+//     ];
+//   },
+//   async headers() {
+//     return [
+//       {
+//         source: "/:path*",
+//         headers: [
+//           {
+//             key: "Link",
+//             value: '<https://granameapp.com>; rel="canonical"',
+//           },
+//         ],
+//       },
+//     ];
+//   },
+// };
+
+// export default nextConfig;
+// /** @type {import('next').NextConfig} 
+// const nextConfig = {
+//   images: {
+//     domains: [
+//       "bubblev2.s3.us-east-1.amazonaws.com",
+//       "talktango.estamart.com",
+//       "picsum.photos",
+//     ],
+//   },
+//   async redirects() {
+//     return [
+//       // Redirect http://granameapp.com/* to https://granameapp.com/*
+//       {
+//         source: "/:path*",
+//         has: [{ type: "host", value: "granameapp.com" }],
+//         protocol: "http",
+//         destination: "https://granameapp.com/:path*",
+//         permanent: true,
+//       },
+//       // Redirect www.granameapp.com/* (http or https) to https://granameapp.com/*
+//       {
+//         source: "/:path*",
+//         has: [{ type: "host", value: "www.granameapp.com" }],
+//         destination: "https://granameapp.com/:path*",
+//         permanent: true,
+//       },
+//     ];
+//   },
+//   async headers() {
+//     return [
+//       {
+//         source: "/:path*",
+//         headers: [
+//           {
+//             key: "Link",
+//             value: '<https://granameapp.com/>; rel="canonical"',
+//           },
+//         ],
+//       },
+//     ];
+//   },
+// };
+
+export default nextConfig;*/
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
@@ -78,6 +158,7 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      // Redirect www.granameapp.com/* (http or https) to https://granameapp.com/*
       {
         source: "/:path*",
         has: [{ type: "host", value: "www.granameapp.com" }],
@@ -93,7 +174,7 @@ const nextConfig = {
         headers: [
           {
             key: "Link",
-            value: '<https://granameapp.com>; rel="canonical"',
+            value: '<https://granameapp.com/>; rel="canonical"',
           },
         ],
       },


### PR DESCRIPTION
fixed domain issues
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes domain redirection and canonical link issues in `next.config.mjs` for Grana-Me app.
> 
>   - **Redirects**:
>     - In `next.config.mjs`, added redirect from `www.granameapp.com/*` to `https://granameapp.com/*`.
>   - **Headers**:
>     - Set canonical link header to `https://granameapp.com/` in `next.config.mjs`.
>   - **Images**:
>     - Allowed image domains: `bubblev2.s3.us-east-1.amazonaws.com`, `talktango.estamart.com`, `picsum.photos`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=mahevstark%2Ftalk-tango&utm_source=github&utm_medium=referral)<sup> for 6de804f8f82c5b18c397a6680fb21dda55374983. You can [customize](https://app.ellipsis.dev/mahevstark/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->